### PR TITLE
fix: fix carousel behaviour

### DIFF
--- a/src/app/landing/carousel/carousel.component.css
+++ b/src/app/landing/carousel/carousel.component.css
@@ -1,3 +1,8 @@
+:host {
+  width: 100%;
+  display: block;
+}
+
 ul {
   list-style: none;
   margin: 0;
@@ -32,14 +37,32 @@ ul {
   width: 167px;
   border-radius: 2px;
   background-color: #F5F6FA;
+  display: flex;
+  align-items: center;
+  align-content: center;
 }
 
 .carousel-date {
-  width: 134px;
+  width: 100%;
   color: #7A7D8C;
   font-family: Nunito;
   font-size: 16px;
   line-height: 22px;
+  text-align: center;
+}
+
+.carousel-item-wrapper {
+  width: 50%;
+}
+
+.carousel-inner {
+  width: 200%;
+  transition: none;
+}
+
+.carousel-inner--transition {
+  transition: transform cubic-bezier(.63,0,.56,.96) 0.8s;
+  transform: translateX(-50%);
 }
 
 .carousel-arrow{

--- a/src/app/landing/carousel/carousel.component.html
+++ b/src/app/landing/carousel/carousel.component.html
@@ -1,17 +1,20 @@
-<div class="carousel-wrapper" [ngStyle]="carouselWrapperStyle">
-  <ul class="carousel-inner" #carousel>
-    <li *ngFor="let item of items;" class="carousel-item active">
-      <div class="row" [ngStyle]="carouselItemStyle">
-        <div class="col-sm-8 text-left carousel-text">
-          {{item.headline}}
+<div class="carousel-wrapper">
+  <ul class="carousel-inner" #carousel
+      (transitionend)="onCarouselTransitionEnd()"
+      [class.carousel-inner--transition]="moveCarousel">
+    <ng-container *ngFor="let item of currentItems">
+      <div class="carousel-item-wrapper" *ngIf="item">
+        <div class="row">
+          <div class="col-sm-8 text-left carousel-text">
+            {{item.headline}}
+          </div>
+          <div class="col-sm-3 carousel-date-placeholder">
+            <span class="carousel-date">{{item.creationTimeMillis | date}}</span>
+          </div>
         </div>
-        <div class="col-sm-3 carousel-date-placeholder">
-          <span class="carousel-date">{{item.creationTimeMillis | date}}</span>
-        </div>
-        <!--<div class="col-sm-1 carousel-arrow">-->
-          <!--<a [routerLink]="['/news']" class="grassroot-link"><i class="fas fa-arrow-right"></i></a>-->
-        <!--</div>-->
       </div>
-    </li>
+    </ng-container>
   </ul>
 </div>
+
+

--- a/src/app/landing/carousel/carousel.component.ts
+++ b/src/app/landing/carousel/carousel.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   Component,
   ElementRef,
   Inject,
@@ -9,9 +8,7 @@ import {
   SimpleChanges,
   ViewChild
 } from '@angular/core';
-// import { CarouselItemDirective } from './carousel-item.directive';
-import {animate, AnimationBuilder, AnimationFactory, AnimationPlayer, style} from '@angular/animations';
-import {interval} from 'rxjs';
+
 import {isPlatformBrowser} from "@angular/common";
 import {PublicLivewire} from "../../livewire/public-livewire.model";
 
@@ -21,108 +18,70 @@ import {PublicLivewire} from "../../livewire/public-livewire.model";
   templateUrl: './carousel.component.html',
   styleUrls: ['./carousel.component.css'],
 })
-export class CarouselComponent<T> implements AfterViewInit, OnChanges {
+export class CarouselComponent implements OnChanges {
   @ViewChild('carousel') private carousel : ElementRef;
   @Input() timing = '800ms ease-in';
   @Input() durationBetweenScrolls: number = 2000;
-  @Input() items: any[] = [];
+
   @Input() propertiesToDisplay: string[] = [];
-  @Input() carouselContainerWidth: number;
   @Input() scrollDirection: string = 'left';
-  private player : AnimationPlayer;
-  private itemWidth : number;
+
+  @Input() items: PublicLivewire[] = [];
+
+
   carouselWrapperStyle = {};
   carouselItemStyle = {};
+  moveCarousel: boolean;
 
-  constructor(private builder : AnimationBuilder, @Inject(PLATFORM_ID) protected platformId: Object) {
-  }
+  currentItemIdx: number = 0;
 
-  ngAfterViewInit() {
-    // For some reason only here I need to add setTimeout, in my local env it's working without this.
+  /**
+   * Represents the current 2 items that are showcased in the carousel. The carousel will
+   * transition from the first to the second one and then replace them for the next set of 2.
+   */
+  currentItems: PublicLivewire[] = [];
 
+  constructor(
+    @Inject(PLATFORM_ID) protected platformId: Object) {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['items'] && !changes['items'].firstChange) {
-      if (isPlatformBrowser(this.platformId) && this.items && this.items.length > 1) {
-        this.startAutoScroll();
+    const change = changes['items'];
+    if (change) {
+      let items = change.currentValue as PublicLivewire[];
+      this.currentItems = items.slice(0, 2);
+      this.currentItemIdx = 0;
+      if (isPlatformBrowser(this.platformId) &&
+          this.currentItems &&
+          this.currentItems.length > 1) {
+        this.scrollCarousel();
       }
     }
+  }
 
-    if (changes['carouselContainerWidth']) {
-      this.setWidths();
+  /**
+   * Listener called when the carousel has finished a translate transition.
+   */
+  onCarouselTransitionEnd() {
+    this.currentItemIdx++;
+    if (this.currentItemIdx === this.items.length - 1) {
+      this.currentItemIdx = -1; // -1 represents the last element of the next batch
     }
+    this.currentItems.shift();
+    this.currentItems.push(this.items[this.currentItemIdx + 1]);
+    this.moveCarousel = false;
+    this.scrollCarousel();
   }
 
-  setWidths() {
-    console.log("setting container width to: ", this.carouselContainerWidth);
-    this.itemWidth = this.carouselContainerWidth;
-    this.carouselWrapperStyle = {
-      width: `${this.itemWidth}px`
-    };
-
-    const width = this.carouselContainerWidth;
-    this.carouselItemStyle = {
-      width: `${width}px`
-    };
-  }
-
-
-  public left() {
-    const offset = this.itemWidth;
-    const myAnimation : AnimationFactory = this.buildAnimationNext(offset);
-    this.player = myAnimation.create(this.carousel.nativeElement.children[0]);
-    this.player.play();
-    this.player.onDone(() => {
-      let newArray = [];
-      let firstElement = <PublicLivewire> this.items[0];
-      let newElement = new PublicLivewire(firstElement.headline, firstElement.creationTimeMillis, firstElement.description, firstElement.imageKeys);
-      this.items.shift();
-      newArray = newArray.concat(this.items);
-      newArray.push(newElement);
-      this.items = newArray;
-    });
-
-  }
-
-  right() {
-    const offset = this.itemWidth;
-    const myAnimation : AnimationFactory = this.buildAnimationPrev(offset);
-    this.player = myAnimation.create(this.carousel.nativeElement.children[0]);
-    this.player.play();
-    this.player.onDone(() => {
-      let lastElement = this.items.pop();
-      let newElement = new PublicLivewire(lastElement.headline, lastElement.creationTimeMillis, lastElement.description, lastElement.imageKeys);
-      let newArray = [];
-      newArray.push(newElement);
-      newArray = newArray.concat(this.items);
-      this.items = newArray;
-    });
-
-  }
-
-  private buildAnimationNext( offset ) {
-    return this.builder.build([
-      animate(this.timing, style({ transform: `translateX(-${offset}px)` }))
-    ]);
-  }
-
-  private buildAnimationPrev( offset ) {
-    return this.builder.build([
-      animate(this.timing, style({ transform: `translateX(+${offset}px)` }))
-    ]);
-  }
-
-
-
-  private startAutoScroll() {
-    console.log("starting auto scroll with interval: ", this.durationBetweenScrolls);
-    interval(this.durationBetweenScrolls).subscribe(() => {
-      if(this.scrollDirection === 'left')
-        this.left();
-      else
-        this.right();
-    });
+  /**
+   * Animates the carousel
+   */
+  scrollCarousel() {
+    if (this.currentItems.length > 1) {
+      setTimeout(() => {
+        this.moveCarousel = true;
+      }, this.durationBetweenScrolls);
+    }
   }
 
 }

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -10,13 +10,14 @@
 </div><!-- /.jumbotron -->
 
 <!-- Latest News -->
-
+  
 <div class="section-latest-news">
   <div class="container">
     <div class="latest-news">
       <h2>Latest News</h2>
       <div class="news-headings row" #tasknote>
-        <carousel [items]="newsList" [carouselContainerWidth]="carouselContainerWidth" [durationBetweenScrolls]="3500"></carousel>
+        <carousel [items]="newsList"
+                  [durationBetweenScrolls]="3500"></carousel>
       </div>
     </div>
   </div>

--- a/src/app/landing/landing.component.ts
+++ b/src/app/landing/landing.component.ts
@@ -40,7 +40,6 @@ export class LandingComponent implements OnInit, AfterViewInit, OnDestroy {
   private activitiesPoller: Subscription;
   private newsPoller: Subscription;
 
-  public carouselContainerWidth: number = 0;
   public activitiesHeight: number = 0;
 
   public anchorPoint: string;
@@ -96,8 +95,6 @@ export class LandingComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.carouselContainerWidth = this.carouselPlaceHolder.nativeElement.offsetWidth;
-    console.log("carousel width: ", this.carouselContainerWidth);
     this.cdr.detectChanges();
 
     if (isPlatformBrowser(this.platformId)) {
@@ -105,11 +102,6 @@ export class LandingComponent implements OnInit, AfterViewInit, OnDestroy {
         //console.log('about to alter banner image style');
         this.bannerImageStyle = 'url(/assets/landing/banner_bg.jpg)'; // Image progressive loader
       }, 1500);
-      fromEvent(window, 'resize')
-        .pipe(debounceTime(200))
-        .subscribe(() => {
-          this.carouselContainerWidth = this.carouselPlaceHolder.nativeElement.offsetWidth;
-        })
     }
   }
 


### PR DESCRIPTION
This PR addresses the following:
1. Fixes how the carousel reveals the next element in the queue.
2. Improves app-wide performance by removing the window resize listener. It represented a serious perf leak given that the subscription was never destroy either by manually unsubscribing on component destroy or by using a `takeUntil`.
3. Cleans up the scrolling strategy on the carousel as it won't depend anymore on hardcoded sizes. It's all based on CSS `transform` transitions.

**Before:**
![2018-10-18 13 11 29](https://user-images.githubusercontent.com/3689856/47174833-5d4e1500-d2d7-11e8-9671-e2bb6b0a53b9.gif)

**After:**
![2018-10-18 12 57 09](https://user-images.githubusercontent.com/3689856/47174836-5fb06f00-d2d7-11e8-8e5e-705fb2d4ac49.gif)

