### PR TITLE
feat: improve banner progressive loading and add better spinner

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,6 +41,7 @@ import {ContributeComponent} from "./landing/static/contribute.component";
 import {TimeAgoPipe} from "time-ago-pipe";
 import { HelpComponent } from './help/help.component';
 import { PaymentsService } from './payments.service';
+import { BannerComponent } from './landing/banner/banner.component';
 
 @NgModule({
   declarations: [
@@ -56,6 +57,7 @@ import { PaymentsService } from './payments.service';
     PasswordResetComponent,
     HomeScreenRoutingComponent,
     LandingComponent,
+    BannerComponent,
     CarouselComponent,
     NewsComponent,
     UnsubscribeComponent,

--- a/src/app/landing/banner/banner.component.css
+++ b/src/app/landing/banner/banner.component.css
@@ -1,0 +1,52 @@
+:host {
+  display: block;
+  background: #525252;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.illustration {
+  position: relative;
+  bottom: -17px;
+  z-index: 10;
+  animation: svg-reveal ease 2s forwards;
+  transform: translateY(30px);
+  opacity: 0;
+}
+
+.bg-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: opacity ease 0.5s;
+  min-width: 100%;
+}
+
+.bg-image--shown {
+  opacity: 1;
+}
+
+.bg-image--high-res {
+  z-index: 30;
+}
+
+.bg-image--low-res {
+  z-index: 20;
+}
+
+
+@keyframes svg-reveal {
+  0% {
+    transform: translateY(30px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/src/app/landing/banner/banner.component.html
+++ b/src/app/landing/banner/banner.component.html
@@ -1,0 +1,34 @@
+<img class="bg-image bg-image--low-res"
+     [class.bg-image--shown]="showLowRes"
+     [src]="lowResImagePath"
+     alt="Header image - meet, vote, act"
+     (load)="lowResLoaded()"
+     *ngIf="loadLowRes">
+<img class="bg-image bg-image--high-res"
+     [class.bg-image--shown]="showHighRes"
+     [src]="highResImagePath"
+     alt="Header image - meet, vote, act"
+     (load)="highResLoaded()"
+     (transitionend)="highResTransitionEnd()"
+     *ngIf="loadHighRes">
+
+    
+<svg class="illustration"
+     width="843px"
+     height="360px"
+     preserveAspectRatio="xMaxYMax meet"
+     viewBox="0 0 843 360"
+     version="1.1"
+     aria-hidden="true"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+
+  <desc>Created with Sketch.</desc>
+  <defs></defs>
+  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+      <circle id="Oval" fill="#484848" cx="218" cy="40" r="40"></circle>
+      <path d="M549.754743,69.2087488 L843,359.570186 L239.622988,359.570186 L532.868245,69.2087488 C537.544759,64.5782238 545.078229,64.5782238 549.754743,69.2087488 Z" id="Triangle-Copy" fill="#474747"></path>
+      <path d="M181.442064,190.262273 L345,359.570186 L0.622987693,359.570186 L164.180924,190.262273 C168.785577,185.49574 176.382423,185.364511 181.148955,189.969164 C181.248338,190.065172 181.346056,190.162889 181.442064,190.262273 Z" id="Triangle-Copy-2" fill="#494949"></path>
+      <path d="M368.361024,144.693331 L580,359.574217 L139.622988,359.574217 L351.261964,144.693331 C355.912502,139.971556 363.510262,139.913807 368.232037,144.564344 C368.275358,144.607012 368.318355,144.650009 368.361024,144.693331 Z" id="Triangle" fill="#373737"></path>
+  </g>
+</svg>

--- a/src/app/landing/banner/banner.component.ts
+++ b/src/app/landing/banner/banner.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * This component loads a background image in progressive way: 
+ * inline svg -> low res image -> high res image
+ */
+@Component({
+  selector: 'app-banner',
+  templateUrl: './banner.component.html',
+  styleUrls: ['./banner.component.css']
+})
+export class BannerComponent {
+
+  @Input()
+  lowResImagePath: string;
+
+  @Input()
+  highResImagePath: string;
+
+  loadLowRes: boolean = true;
+  loadHighRes: boolean = false;
+
+  showLowRes = false;
+  showHighRes = false;
+
+  lowResLoaded() {
+    this.showLowRes = true;
+    this.loadHighRes = true;
+  }
+
+  highResLoaded() {
+    this.showHighRes = true;
+  }
+
+  /**
+   * Method called when the high end res finishes its revealing
+   */
+  highResTransitionEnd() {
+    // remove the load res image from the DOM for better a11y (no duplicates)
+    this.loadLowRes = false;
+  }
+
+}

--- a/src/app/landing/landing.component.css
+++ b/src/app/landing/landing.component.css
@@ -13,6 +13,19 @@ fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td {
   font-family: 'Nunito', sans-serif; }
 
+.banner-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 0;
+}
+
+.header-content {
+  display: block;
+}
+
 .alignleft {
   float: left; }
 

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -1,6 +1,9 @@
 
-<div class="jumbotron" id="intro" [style.background-image]="bannerImageStyle" no-repeat>
-  <div class="container text-center">
+<div class="jumbotron" id="intro" no-repeat>
+  <app-banner class="banner-bg"
+              [lowResImagePath]="lowResImagePath"
+              [highResImagePath]="highResImagePath"></app-banner>
+  <div class="container text-center header-content">
     <div class="intro-content">
       <div class="meet-vote-act">MEET, VOTE, ACT </div>
       <h1>Mobilizing your community has never been this easy</h1>

--- a/src/app/landing/landing.component.ts
+++ b/src/app/landing/landing.component.ts
@@ -10,8 +10,7 @@ import {
   ViewChild,
   OnDestroy
 } from '@angular/core';
-import {Subscription, interval, fromEvent } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
+import {Subscription, interval } from 'rxjs';
 import {PublicActivityType} from './model/public-activity-type.enum';
 import {PublicActivity} from './model/public-activity.model';
 import {PublicActivityService} from './public-activity.service';
@@ -37,6 +36,9 @@ export class LandingComponent implements OnInit, AfterViewInit, OnDestroy {
   public activitiesList: PublicActivity[] = [];
   public newsList: PublicLivewire[] = [];
 
+  public readonly lowResImagePath = '/assets/landing/banner_bg1.jpg';
+  public readonly highResImagePath = '/assets/landing/banner_bg.jpg';
+
   private activitiesPoller: Subscription;
   private newsPoller: Subscription;
 
@@ -49,7 +51,7 @@ export class LandingComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public pseudonyms: string[] = [];
 
-  public bannerImageStyle = 'url(/assets/landing/banner_bg1.jpg)'; //Low quality image for progressive loading
+
 
   constructor(private alertService: AlertService,
               private publicActivityService: PublicActivityService,
@@ -96,13 +98,6 @@ export class LandingComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngAfterViewInit(): void {
     this.cdr.detectChanges();
-
-    if (isPlatformBrowser(this.platformId)) {
-      setTimeout(() => {
-        //console.log('about to alter banner image style');
-        this.bannerImageStyle = 'url(/assets/landing/banner_bg.jpg)'; // Image progressive loader
-      }, 1500);
-    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/landing/landing.module.ts
+++ b/src/app/landing/landing.module.ts
@@ -16,7 +16,6 @@ export const LANDING_ROUTE: Routes = [
     SharedModule,
     RouterModule.forChild(LANDING_ROUTE),
   ],
-  declarations: [],
   providers: [
     PublicActivityService,
     PublicNewsService

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,50 @@
   <title>Grassroot</title>
   <base href="/">
 
+  <style>
+    .loader,
+    .loader:after {
+      border-radius: 50%;
+      width: 6em;
+      height: 6em;
+    }
+    .loader {
+      margin: 60px auto;
+      font-size: 10px;
+      position: relative;
+      text-indent: -9999em;
+      border-top: 0.6em solid rgba(187, 187, 187, 0.2);
+      border-right: 0.6em solid rgba(187, 187, 187, 0.2);
+      border-bottom: 0.6em solid rgba(187, 187, 187, 0.2);
+      border-left: 0.6em solid #00c037;
+      -webkit-transform: translateZ(0);
+      -ms-transform: translateZ(0);
+      transform: translateZ(0);
+      -webkit-animation: load8 1.1s infinite linear;
+      animation: load8 1.1s infinite linear;
+    }
+    @-webkit-keyframes load8 {
+      0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+      }
+    }
+    @keyframes load8 {
+      0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+      }
+    }
+  </style>
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
@@ -39,7 +83,7 @@
         font-size: 2.5em;
       }
     </style>
-    Loading ....
+    <div class="loader">Loading...</div>
   </app-root>
 
 


### PR DESCRIPTION
This PR contains three main things:
1. Fixes the banner flashing by improving the progressive rendering of the image
2. Adds an inline svg to improve UI and better contrast/readability 
3. Adds a css spinner to render on load

![2018-10-19 12 55 19](https://user-images.githubusercontent.com/3689856/47235302-43c3d080-d39e-11e8-9bbb-7b7a6fea31af.gif)

The following GIF demonstrates the progressive rendering which doesn't rely on hard coded timeouts, but instead on loading the high res image only when the low res image loads.

![2018-10-19 12 57 56](https://user-images.githubusercontent.com/3689856/47235467-bd5bbe80-d39e-11e8-8245-12987aa8fc52.gif)
