### PR TITLE
fix: fix route to i18n assets

### DIFF
--- a/src/app/translate/translate-server-loader.service.ts
+++ b/src/app/translate/translate-server-loader.service.ts
@@ -18,7 +18,7 @@ export class TranslateServerLoader implements TranslateLoader {
     console.log("getting a translation ... ");
 
     return Observable.create(observer => {
-      const jsonData = JSON.parse(fs.readFileSync(`dist-server/assets/i18n/${lang}${this.suffix}`, 'utf8'));
+      const jsonData = JSON.parse(fs.readFileSync(`dist/assets/i18n/${lang}${this.suffix}`, 'utf8'));
 
       // Here we save the translations in the transfer-state
       const key: StateKey<number> = makeStateKey<number>('transfer-translate-' + lang);


### PR DESCRIPTION
This PR fixes the problems faced with i18n on page load. The problem was that ngx-translate was not able to translate the files on the server because the path was wrong. It worked before because ngx-translate would spin up in the browser and request the file.

These are the server logs:

**Before**
```
Listening at 4000
GET: /: 4.430ms
Initializing user service
constructed translate server module ...
getting a translation ...
are we logged in? :  false
ERROR { Error: ENOENT: no such file or directory, open 'dist-server/assets/i18n/en.json'
    at Object.fs.openSync (fs.js:663:18)
    at Object.fs.readFileSync (fs.js:568:33)
    at Observable._subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/dist-server/main.js:3684:42)
    at Observable._trySubscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:44:25)
    at Observable.subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:30:22)
    at Observable.ConnectableObservable.connect (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/observable/ConnectableObservable.js:47:18)
    at RefCountOperator.call (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/operators/refCount.js:33:49)
    at Observable.subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:25:22)
    at TakeOperator.call (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/operators/take.js:38:23)
    at Observable.subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:25:22)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'dist-server/assets/i18n/en.json' }
ERROR { Error: ENOENT: no such file or directory, open 'dist-server/assets/i18n/en.json'
    at Object.fs.openSync (fs.js:663:18)
    at Object.fs.readFileSync (fs.js:568:33)
    at Observable._subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/dist-server/main.js:3684:42)
    at Observable._trySubscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:44:25)
    at Observable.subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:30:22)
    at Observable.ConnectableObservable.connect (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/observable/ConnectableObservable.js:47:18)
    at RefCountOperator.call (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/operators/refCount.js:33:49)
    at Observable.subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:25:22)
    at TakeOperator.call (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/operators/take.js:38:23)
    at Observable.subscribe (/Users/carlos/Desktop/hacks/grassroot-frontend/node_modules/rxjs/internal/Observable.js:25:22)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
```

**After**
```
Listening at 4000
GET: /: 1.514ms
Initializing user service
constructed translate server module ...
getting a translation ...
are we logged in? :  false
```

There are no more text flashings on page load as the translations come set up from the server. I've built the docker image locally and run the container to double check that everything works correctly.