### PR TITLE
Fix/firefox loading

### DIFF
--- a/src/app/landing/banner/banner.component.css
+++ b/src/app/landing/banner/banner.component.css
@@ -21,7 +21,6 @@
 .bg-image {
   position: absolute;
   top: 0;
-  left: 0;
   opacity: 0;
   transition: opacity ease 0.5s;
   min-width: 100%;
@@ -48,5 +47,11 @@
   100% {
     transform: translateY(0);
     opacity: 1;
+  }
+}
+
+@media (max-width: 767px) {
+  .bg-image {
+    height: 100%;
   }
 }

--- a/src/app/landing/carousel/carousel.component.css
+++ b/src/app/landing/carousel/carousel.component.css
@@ -68,3 +68,19 @@ ul {
 .carousel-arrow{
   color: #2CBC4C;
 }
+
+@media (max-width: 767px) {
+  .carousel-text {
+    width: 100%;
+  }
+
+  .carousel-date-placeholder {
+    background: none;
+    width: 100%;
+  }
+
+  .carousel-date {
+    font-weight: 600;
+    opacity: 0.4;
+  }
+}

--- a/src/app/landing/carousel/carousel.component.html
+++ b/src/app/landing/carousel/carousel.component.html
@@ -5,10 +5,10 @@
     <ng-container *ngFor="let item of currentItems">
       <div class="carousel-item-wrapper" *ngIf="item">
         <div class="row">
-          <div class="col-sm-8 text-left carousel-text">
+          <div class="col-sm-8 text-center text-md-left carousel-text">
             {{item.headline}}
           </div>
-          <div class="col-sm-3 carousel-date-placeholder">
+          <div class="col-sm-3 carousel-date-placeholder text-center text-md-left">
             <span class="carousel-date">{{item.creationTimeMillis | date}}</span>
           </div>
         </div>

--- a/src/app/landing/carousel/carousel.component.ts
+++ b/src/app/landing/carousel/carousel.component.ts
@@ -34,6 +34,7 @@ export class CarouselComponent implements OnChanges {
   moveCarousel: boolean;
 
   currentItemIdx: number = 0;
+  scrollTimeout: any;
 
   /**
    * Represents the current 2 items that are showcased in the carousel. The carousel will
@@ -53,7 +54,8 @@ export class CarouselComponent implements OnChanges {
       this.currentItemIdx = 0;
       if (isPlatformBrowser(this.platformId) &&
           this.currentItems &&
-          this.currentItems.length > 1) {
+          this.currentItems.length > 1 &&
+          !this.scrollTimeout) {
         this.scrollCarousel();
       }
     }
@@ -78,7 +80,7 @@ export class CarouselComponent implements OnChanges {
    */
   scrollCarousel() {
     if (this.currentItems.length > 1) {
-      setTimeout(() => {
+      this.scrollTimeout = setTimeout(() => {
         this.moveCarousel = true;
       }, this.durationBetweenScrolls);
     }

--- a/src/app/landing/landing.component.css
+++ b/src/app/landing/landing.component.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css?family=Nunito:300,300i,400,400i,600,600i");
-
 .clearfix {
   clear: both; }
 
@@ -166,7 +164,7 @@ p {
     margin: 0rem 1rem; }
 
   #intro {
-    min-height: 530px; }
+    min-height: 528px; }
   #intro h1 {
     font-size: 55px;
     line-height: 65px; }

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -17,7 +17,7 @@
 <div class="section-latest-news">
   <div class="container">
     <div class="latest-news">
-      <h2>Latest News</h2>
+      <h2 class="text-center text-md-left">Latest News</h2>
       <div class="news-headings row" #tasknote>
         <carousel [items]="newsList"
                   [durationBetweenScrolls]="3500"></carousel>

--- a/src/app/landing/news-style.css
+++ b/src/app/landing/news-style.css
@@ -38,9 +38,7 @@
 
   .section-latest-news .latest-news h2 {
     margin: 0;
-    position: absolute;
     padding-right: 10px;
-    border-right: 1px solid #4a4a4a;
   }
 
   .section-latest-news .posted-on {
@@ -53,6 +51,11 @@
 }
 
 @media (min-width: 768px) {
+
+  .section-latest-news .latest-news h2 {
+    position: absolute;
+    border-right: 1px solid #4a4a4a;
+  }
 
   .section-latest-news .item {
     display: flex;

--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
   <link href="assets/fonts/icomoon-fonts.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Nunito:300,300i,400,400i,600,600i" rel="stylesheet">
 
   <script async defer src="https://use.fontawesome.com/releases/v5.0.2/js/all.js"></script>
 


### PR DESCRIPTION
This PR contains several fixes:

1. No more shrinking header in Firefox. I fixed this by offloading the `landing.components.css` from importing the font directly in the css file. This has a performance impact because the css was not being evaluated until the font could be downloaded/resolved. That's why it's generally recommended [not to use import to fetch fonts](http://www.stevesouders.com/blog/2009/04/09/dont-use-import/). I've moved the font fetching to the index.html.
2. Improved responsiveness of the carousel.

**Before:**
![2018-10-22 13 09 29](https://user-images.githubusercontent.com/3689856/47310583-30fb0700-d5fd-11e8-89a4-828577075f91.gif)

**After:**
![2018-10-22 13 09 13](https://user-images.githubusercontent.com/3689856/47310559-2476ae80-d5fd-11e8-89fa-22734d1b8bcd.gif)

3. Fixed a perf leak in the carousel that was creating chained timeouts when the news items changed.
4. Fixed the banner responsiveness (centered in mobile, expanded in large screens while maintaining the aspect ratio).
![2018-10-22 13 22 13](https://user-images.githubusercontent.com/3689856/47310696-859e8200-d5fd-11e8-86e8-43af787f6dc4.gif)

