### PR TITLE
fix: fix shuddering on spinner

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -2,6 +2,16 @@
   padding-top: 70px;
 }
 
+.loading-spinner {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  overflow: hidden;
+}
+
 .navbar {
   padding-bottom: 0 !important;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,6 @@
-<ngx-loading [show]="loadingModule" [config]="{ backdropBackgroundColour: 'rgba(255,255,255,0.3)'}"></ngx-loading>
+<ngx-loading [show]="loadingModule"
+             class="loading-spinner"
+             [config]="{ backdropBackgroundColour: 'rgba(255,255,255,0.3)'}"></ngx-loading>
 <div class="container-fluid">
 
   <div class="container-fluid bg-white fixed-top">


### PR DESCRIPTION
This PR fixes the screen shuddering that shows up on loading. As shown below, this happens because the loading element overflows its parent when rotating. This causes the scrollbar to intermittently 
 show up and hide (because the element keeps rotating). As we're not interested in showing the rotating container, which is invisible btw, then we're safe setting configuring the parent to hide its overflowing children.

![2018-10-23 10 59 21](https://user-images.githubusercontent.com/3689856/47374091-c0162680-d6b2-11e8-8f1b-19b2585f2ef4.gif)