### PR TITLE
Feat/quill inline image

### DIFF
--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -16,6 +16,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AdminAccountsComponent } from './accounts/admin-accounts.component';
 import { AccountsAdminService } from './admin-accounts.service';
 import { AccountDetailComponent } from './accounts/account-detail/account-detail.component';
+import { QuillModule } from "ngx-quill";
 
 @NgModule({
   imports: [
@@ -23,6 +24,7 @@ import { AccountDetailComponent } from './accounts/account-detail/account-detail
     SharedModule,
     LoggedInServicesModule,
     NgbModule,
+    QuillModule,
     RouterModule.forChild(ADMIN_ROUTES)
   ],
   declarations: [

--- a/src/app/admin/livewire/alert-view/view-alert.component.css
+++ b/src/app/admin/livewire/alert-view/view-alert.component.css
@@ -1,3 +1,5 @@
+@import "https://cdn.quilljs.com/1.2.2/quill.snow.css";
+
 .headline{
 	margin-bottom: 1%;
 }
@@ -54,3 +56,6 @@
     transition: 0.3s;
 }
 
+.cancel-btn {
+  border-radius: 100px;
+}

--- a/src/app/admin/livewire/alert-view/view-alert.component.html
+++ b/src/app/admin/livewire/alert-view/view-alert.component.html
@@ -4,7 +4,7 @@
 	<a [routerLink]="['/admin/livewire/list']" class="grassroot-breadcrumb"><i
 		class="fas fa-arrow-left"></i>BACK TO ALERTS</a>
 
-	<div class="row" *ngIf="!liveWireAlert.sent">
+	<div class="row" *ngIf="!liveWireAlert?.sent">
 		<div class="col-md-1">
 			<button class="btn btn-secondary" (click)="openReleaseModal()">Release</button>
 		</div>
@@ -49,10 +49,20 @@
 			<div class="row description">
 				<div class="col-md-2" style="font-weight: bold;">Description</div>
 				<div class="col-md-4" [innerHtml]="liveWireAlert.description">Description</div>
-				<div class="col-md-4">
+				<div class="col-md-6">
 					<button class="btn btn-primary"
-						(click)="openDescriptionModal(liveWireAlert.description)">Edit</button>
-				</div>
+            (click)="onEditDescriptionClick()">{{ getEditDescriptionText() }}</button>
+          <button class="btn btn-outline-secondary cancel-btn ml-3"
+            *ngIf="showDescription"
+            (click)="cancelEditDescription()">Cancel</button>
+        </div>
+        <div class="col-md-8 offset-md-2 mt-2">
+          <quill-editor *ngIf="showDescription"
+                        [style]="{height: '180px'}"
+                        [modules]="quillConfig"
+                        [ngModel]="liveWireAlert.description"
+                        (ngModelChange)="descriptionText = $event"></quill-editor>
+        </div>
 			</div>
 			<hr />
 			<div class="row group">
@@ -144,42 +154,6 @@
 				<div class="modal-footer">
 					<button class="btn btn-secondary" data-dismiss="modal">Cancel</button>
 					<button class="btn btn-danger" (click)="updateHeadline(headline)">Edit</button>
-				</div>
-
-			</div>
-		</div>
-	</div>
-
-	<div class="modal fade" tabindex="-1" role="dialog"
-		id="change-description-modal" aria-hidden="true">
-		<div class="modal-dialog modal-md" role="document">
-			<div class="modal-content">
-				<span class="alert-modal-image-close">&times;</span>
-				<div class="modal-header">
-					<h5 class="modal-title">{{'livewire.desc-modal.title' |
-						translate}}</h5>
-					<button type="button" class="close" data-dismiss="modal"
-						aria-label="Close">
-						<span aria-hidden="true">&times;</span>
-					</button>
-				</div>
-
-				<div class="modal-body">
-					<div class="form-group">
-						<label for="description-text" class="control-label">{{'livewire.desc-modal.label'
-							| translate}}</label>
-
-						<textarea class="form-control" #description rows="" cols=""
-							id="description-text" name="description-text">
-        		{{desc}}
-        	</textarea>
-					</div>
-				</div>
-
-				<div class="modal-footer">
-					<button class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-					<button class="btn btn-danger"
-						(click)="updateDescription(description.value)">Edit</button>
 				</div>
 
 			</div>

--- a/src/app/admin/livewire/alert-view/view-alert.component.ts
+++ b/src/app/admin/livewire/alert-view/view-alert.component.ts
@@ -30,9 +30,11 @@ export class ViewAlertComponent implements OnInit {
   public subscribers:DataSubscriber[] = [];
   public shareOnFB:boolean = false;
   public shareOnTwitter:boolean = false;
-
+  public showDescription = false;
+  public descriptionText: string = '';
   private linkUrl:string = "";
   private linkName:string = "grassroor news";
+  public quillConfig: any;
 
   constructor(private route:ActivatedRoute,
               private liveWireAlertService:LiveWireAdminService,
@@ -54,6 +56,19 @@ export class ViewAlertComponent implements OnInit {
     },error=>{
       console.log("Error getting params....",error);
     });
+    // basic Quill config for description (no media, no complex formatting)
+    this.quillConfig = {
+      toolbar: [
+        ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
+        [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+        [{ 'script': 'sub'}, { 'script': 'super' }],      // superscript/subscript
+        ['clean'],                                         // remove formatting button
+      ]
+    };
+  }
+
+  cancelEditDescription() {
+    this.showDescription = false;
   }
 
   loadAlert(alertUid:string){
@@ -83,6 +98,17 @@ export class ViewAlertComponent implements OnInit {
   openDescriptionModal(description:string){
     this.desc = description;
     $('#change-description-modal').modal("show");
+  }
+
+  onEditDescriptionClick() {
+    if (this.showDescription) {
+      this.updateDescription(this.descriptionText);
+    }
+    this.showDescription = !this.showDescription;
+  }
+
+  getEditDescriptionText(): string {
+    return this.showDescription ? 'Save' : 'Edit';
   }
 
   updateHeadline(headline:string){

--- a/src/app/broadcasts/broadcast-create/broadcast-confirm/broadcast-confirm.component.ts
+++ b/src/app/broadcasts/broadcast-create/broadcast-confirm/broadcast-confirm.component.ts
@@ -4,7 +4,7 @@ import {BroadcastService} from "../../broadcast.service";
 import {Router} from "@angular/router";
 import {BroadcastConfirmation, BroadcastContent} from "../../model/broadcast-request";
 import {AlertService} from "../../../utils/alert-service/alert.service";
-import {emailStyleHeader, limitImageSizesInRichText, replaceImagesInRichText} from "../../../media/media-utils";
+import {emailStyleHeader, replaceImagesInRichText} from "../../../media/media-utils";
 
 @Component({
   selector: 'app-broadcast-confirm',

--- a/src/app/broadcasts/broadcast-create/broadcast-content/broadcast-content.component.html
+++ b/src/app/broadcasts/broadcast-create/broadcast-content/broadcast-content.component.html
@@ -64,7 +64,9 @@
         </div>
         <div class="form-row mb-md-3" *ngIf="types.email">
           <div class="form-group col-sm-12">
-            <quill-editor #emailEditor [style]="{height: '180px'}" [formControlName]="'emailContent'"></quill-editor>
+            <quill-editor (onEditorCreated)="onEditorCreated($event)"
+                          [style]="{height: '180px'}"
+                          [formControlName]="'emailContent'"></quill-editor>
           </div>
         </div>
         <div class="row" *ngIf="types.email">

--- a/src/app/media/media-utils.ts
+++ b/src/app/media/media-utils.ts
@@ -2,17 +2,6 @@ const quillImgSrcReg = /<img[^>]+src/g;
 // const quillImgSrcReg = /<img.+src=\".+\">/g;
 const fullImgSrcReg = /<img[^>]+>/g;
 
-export const limitImageSizesInRichText = (emailHtml: string, maxWidth: number = 640): string => {
-  const foundImg = emailHtml.match(quillImgSrcReg);
-  console.log('do we have a match? ', foundImg && foundImg.length > 0);
-  console.log('found image length: ', foundImg && foundImg.length || 0);
-  // console.log('inbound content: ', emailHtml);
-  quillImgSrcReg.lastIndex = 0;
-  const replacedHtml = emailHtml.replace(quillImgSrcReg, `<img style="max-width: ${maxWidth}px !important" src`);
-  // console.log('replaced email: ', replacedHtml);
-  return foundImg ? emailStyleHeader + replacedHtml : emailHtml;
-};
-
 export const emailStyleHeader = '<style>img { ' +
   'max-width: 640px ' +
   '}' +
@@ -26,3 +15,58 @@ export const emailStyleHeader = '<style>img { ' +
 export const replaceImagesInRichText = (emailHtml: string): string => {
   return emailHtml.replace(fullImgSrcReg, "<br><i>[inline image]</i></br>");
 };
+
+/**
+ * Creates a Parchment Embed format to add custom small images.
+ * A Parchment Embed allows us to create custom content in Quill with a custom format.
+ * Our custom format is called 'small-image'.
+ *
+ * @export
+ * @param embed - the Parchment.Embed class which our custom Embed inherits from
+ * @returns - the class which must be registered in Quill to render the new format
+ */
+export function createCustomImageEmbed(embed: any, maxWidth: number = 640) {
+  const embedBlot = class SmallImage extends embed {
+    static blotName = 'small-image'; 
+    static className = 'small-image';
+    static tagName = 'img';
+    static create(value) {
+      let node = super.create(value);
+      node.setAttribute('style', `max-width: ${maxWidth}px`);
+      node.setAttribute('src', value);
+      return node;
+    }
+  }
+  return embedBlot;
+}
+
+/**
+ * Creates a custom handler for embedding images. Every image will be added
+ * with a max-width: 640px style to avoid rendering issues in emails
+ *
+ * @export
+ * @param editor
+ * @returns
+ */
+export function getCustomImageHandler(editor) {
+  return () => {
+    let fileInput: HTMLInputElement;
+    fileInput = document.createElement('input');
+    fileInput.setAttribute('type', 'file');
+    fileInput.setAttribute(
+      'accept',
+      'image/png, image/gif, image/jpeg, image/bmp, image/x-icon'
+    );
+    fileInput.addEventListener('change', () => {
+      if (fileInput.files != null && fileInput.files[0] != null) {
+        var reader = new FileReader();
+        reader.onload = e => {
+          const range = editor.getSelection();
+          editor.insertEmbed(range.index, 'small-image', (e.target as any).result);
+        }
+        reader.readAsDataURL(fileInput.files[0]);
+      }
+    });
+    fileInput.click();
+  }
+}


### PR DESCRIPTION
This PR contains two main features:
1. Adds Quill editor to edit the description within the ViewAlertComponent. I have limited the number of features in Quill for this particular use case as I imagine we don't want descriptions with media or fancy formatting.

![2018-10-24 15 47 50](https://user-images.githubusercontent.com/3689856/47460612-81f92f80-d7a4-11e8-8c15-eca7dcc793fd.gif)

2. Enforce a max-width: 640px in all images that are inserted in Quill when trying to broadcast a message via email. We achieve that by leveraging Quill custom handlers (to hijack the image upload event) and the Parchment Embed feature (to embeded custom content - a "small" image)

![2018-10-24 15 49 15](https://user-images.githubusercontent.com/3689856/47460811-e87e4d80-d7a4-11e8-973f-1424e5759ac9.gif)
